### PR TITLE
Change Curly Braces to Square Brackets

### DIFF
--- a/src/i_introduction/_1_Java_To_Kotlin_Converter/JavaCode1.java
+++ b/src/i_introduction/_1_Java_To_Kotlin_Converter/JavaCode1.java
@@ -8,7 +8,7 @@ import java.util.Iterator;
 public class JavaCode1 extends JavaCode {
     public String task1(Collection<Integer> collection) {
         StringBuilder sb = new StringBuilder();
-        sb.append("{");
+        sb.append("[");
         Iterator<Integer> iterator = collection.iterator();
         while (iterator.hasNext()) {
             Integer element = iterator.next();
@@ -17,7 +17,7 @@ public class JavaCode1 extends JavaCode {
                 sb.append(", ");
             }
         }
-        sb.append("}");
+        sb.append("]");
         return sb.toString();
     }
 }


### PR DESCRIPTION
At the last update of Kotlin Koans. It didn't accept the answer and give the 'The function 'toJSON' is implemented incorrectly:  expected:[[1, 2, 3, 42, 555]]> but was:[{1, 2, 3, 42, 555}]>'.